### PR TITLE
CF-2650 - As a user I would like to wire the workflow volume to composition services

### DIFF
--- a/lib/transformers/IntrusiveFeaturesValidator.js
+++ b/lib/transformers/IntrusiveFeaturesValidator.js
@@ -24,12 +24,12 @@ function validateVolumes(compositionObject) {
     var localFilesystemVolumes = _.any(volumesDeclarations, function (volumeDeclaration) {
 
         var sourceVolume;
-        if (volumeDeclaration.includes(':')) {
-            var externalVolumeElements = volumeDeclaration.split(':');
-            sourceVolume  = externalVolumeElements[0];
-        } else {
-            sourceVolume = volumeDeclaration;
+        if (!volumeDeclaration.includes(':')) {
+            return false;
         }
+
+        var externalVolumeElements = volumeDeclaration.split(':');
+        sourceVolume  = externalVolumeElements[0];
 
         return sourceVolume.includes('.') || sourceVolume.includes('/') || sourceVolume.includes('~');
     });

--- a/lib/transformers/IntrusiveFeaturesValidator.js
+++ b/lib/transformers/IntrusiveFeaturesValidator.js
@@ -21,9 +21,20 @@ function validateExplicitlyExportedPorts(compositionObject) {
 
 function validateVolumes(compositionObject) {
     var volumesDeclarations = declarationInComposition(compositionObject, 'volumes');
-    var volumesFromDeclarations = declarationInComposition(compositionObject, 'volumes_from');
-    if ((volumesDeclarations.length > 0) || volumesFromDeclarations.length > 0) {
-        throw new Error("Composition cannot mount any volumes");
+    var localFilesystemVolumes = _.any(volumesDeclarations, function (volumeDeclaration) {
+
+        var sourceVolume;
+        if (volumeDeclaration.includes(':')) {
+            var externalVolumeElements = volumeDeclaration.split(':');
+            sourceVolume  = externalVolumeElements[0];
+        } else {
+            sourceVolume = volumeDeclaration;
+        }
+
+        return sourceVolume.includes('.') || sourceVolume.includes('/') || sourceVolume.includes('~');
+    });
+    if (localFilesystemVolumes) {
+        throw new Error("Composition cannot mount volumes from the local filesystem");
     }
 }
 

--- a/test/tests.unit.spec.js
+++ b/test/tests.unit.spec.js
@@ -375,12 +375,7 @@ describe("Transform composition", function () {
             validateIntrusiveFeatures: true
         });
 
-        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n')
-            .then(function () {
-            return Q.reject(new Error('The test should have failed on intrusive feature validation'));
-        }, function (err) {
-            expect(err.message).to.equal('Composition cannot mount volumes from the local filesystem');
-        });
+        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n');
     });
 
     it("From YAML with auto-created volume and intrusive validation switched off", () => {

--- a/test/tests.unit.spec.js
+++ b/test/tests.unit.spec.js
@@ -370,32 +370,62 @@ describe("Transform composition", function () {
             });
     });
 
-    it("From YAML with mounted volumes and intrusive validation switched on", function (done) {
+    it("From YAML with auto-created volume and intrusive validation switched on", () => {
         var transformer = new Transformer({
             validateIntrusiveFeatures: true
         });
 
-        transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n')
+        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n')
             .then(function () {
-                done("The test should have failed on intrusive feature validation");
+            return Q.reject(new Error('The test should have failed on intrusive feature validation'));
+        }, function (err) {
+            expect(err.message).to.equal('Composition cannot mount volumes from the local filesystem');
+        });
+    });
+
+    it("From YAML with auto-created volume and intrusive validation switched off", () => {
+        var transformer = new Transformer({
+            validateIntrusiveFeatures: false
+        });
+
+        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n');
+    });
+
+    it("From YAML with container volume and intrusive validation switched on", () => {
+        var transformer = new Transformer({
+            validateIntrusiveFeatures: true
+        });
+
+        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "some-container-volume:/j/b"\n');
+    });
+
+    it("From YAML with container volume and intrusive validation switched off", () => {
+        var transformer = new Transformer({
+            validateIntrusiveFeatures: false
+        });
+
+        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "some-container-volume:/j/b"\n');
+    });
+
+    it("From YAML with local filesystem volumes and intrusive validation switched on", () => {
+        var transformer = new Transformer({
+            validateIntrusiveFeatures: true
+        });
+
+        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n')
+            .then(function () {
+                return Q.reject(new Error('The test should have failed on intrusive feature validation'));
             }, function (err) {
-                expect(err.message).to.equal("Composition cannot mount any volumes");
-                done();
+                expect(err.message).to.equal('Composition cannot mount volumes from the local filesystem');
             });
     });
 
-    it("From YAML with volumes_from and intrusive validation switched on", function (done) {
+    it("From YAML with local filesystem volumes and intrusive validation switched off", () => {
         var transformer = new Transformer({
-            validateIntrusiveFeatures: true
+            validateIntrusiveFeatures: false
         });
 
-        transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes_from:\n   - "theotherimage"\n')
-            .then(function () {
-                done("The test should have failed on intrusive feature validation");
-            }, function (err) {
-                expect(err.message).to.equal("Composition cannot mount any volumes");
-                done();
-            });
+        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n');
     });
 
     it("should run transform handler after replacement of composition vars", function () {


### PR DESCRIPTION
Refine the intrusive volume validation:
The validation used to deny access to all volumes if not on dedicated hardware. This no longer fits the model of the composition in the new workflow as it needs access to the workflow data volume.
From now on a user can specify data volumes and connect volumes between containers and required dedicated hardware only when wanting to use volumes from the local file system
