### PR TITLE
CF-3021 - environment logs should keep updating even after new pushes of the runtime

### DIFF
--- a/lib/transformers/DockerCompose.js
+++ b/lib/transformers/DockerCompose.js
@@ -286,8 +286,22 @@ DockerComposeTransformer.prototype.validateIntrusiveFeatures = function(yamlStri
     }
 
     try {
-        var compositionObject = YAML.load(yamlString);
-        IntrusiveFeaturesValidator.validate(compositionObject);
+        var compositionServices = YAML.safeLoad(yamlString);
+
+        // remove all services that were marked by the engine explicitly to not be validated
+        compositionServices = _.filter(compositionServices, function(service) {
+            return !service.dontValidateIntrusiveFeatures;
+        });
+
+        IntrusiveFeaturesValidator.validate(compositionServices);
+
+        // remove all occurencees of dontValidateIntrusiveFeatures field on services
+        compositionServices = YAML.safeLoad(yamlString);
+        _.forEach(compositionServices, function(service) {
+            delete service.dontValidateIntrusiveFeatures;
+        });
+        yamlString = YAML.dump(compositionServices);
+
     } catch (e) {
         return Q.reject(e);
     }

--- a/lib/transformers/DockerCompose.js
+++ b/lib/transformers/DockerCompose.js
@@ -289,7 +289,7 @@ DockerComposeTransformer.prototype.validateIntrusiveFeatures = function(yamlStri
         var compositionObject = YAML.safeLoad(yamlString);
 
         // remove all services that were marked by the engine explicitly to not be validated
-        if (_.get(compositionObject, 'version', '') === 2) {
+        if (_.get(compositionObject, 'version', '').toString() === '2') {
             compositionObject.services = _.filter(compositionObject.services, function(service) {
                 return !service.dontValidateIntrusiveFeatures;
             });
@@ -304,7 +304,7 @@ DockerComposeTransformer.prototype.validateIntrusiveFeatures = function(yamlStri
         // remove all occurencees of dontValidateIntrusiveFeatures field on services
         compositionObject = YAML.safeLoad(yamlString);
         var compositionServices;
-        if (_.get(compositionObject, 'version', '') === 2) {
+        if (_.get(compositionObject, 'version', '').toString() === '2') {
             compositionServices = compositionObject.services;
         } else {
             compositionServices = compositionObject;

--- a/lib/transformers/DockerCompose.js
+++ b/lib/transformers/DockerCompose.js
@@ -286,21 +286,33 @@ DockerComposeTransformer.prototype.validateIntrusiveFeatures = function(yamlStri
     }
 
     try {
-        var compositionServices = YAML.safeLoad(yamlString);
+        var compositionObject = YAML.safeLoad(yamlString);
 
         // remove all services that were marked by the engine explicitly to not be validated
-        compositionServices = _.filter(compositionServices, function(service) {
-            return !service.dontValidateIntrusiveFeatures;
-        });
+        if (_.get(compositionObject, 'version', '') === 2) {
+            compositionObject.services = _.filter(compositionObject.services, function(service) {
+                return !service.dontValidateIntrusiveFeatures;
+            });
+        } else {
+            compositionObject = _.filter(compositionObject, function(service) {
+                return !service.dontValidateIntrusiveFeatures;
+            });
+        }
 
-        IntrusiveFeaturesValidator.validate(compositionServices);
+        IntrusiveFeaturesValidator.validate(compositionObject);
 
         // remove all occurencees of dontValidateIntrusiveFeatures field on services
-        compositionServices = YAML.safeLoad(yamlString);
+        compositionObject = YAML.safeLoad(yamlString);
+        var compositionServices;
+        if (_.get(compositionObject, 'version', '') === 2) {
+            compositionServices = compositionObject.services;
+        } else {
+            compositionServices = compositionObject;
+        }
         _.forEach(compositionServices, function(service) {
             delete service.dontValidateIntrusiveFeatures;
         });
-        yamlString = YAML.dump(compositionServices);
+        yamlString = YAML.dump(compositionObject);
 
     } catch (e) {
         return Q.reject(e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-compose",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "codefresh compose utility",
   "main": "index.js",
   "bin": {

--- a/test/tests.unit.spec.js
+++ b/test/tests.unit.spec.js
@@ -356,94 +356,127 @@ describe("Transform composition", function () {
             });
     });
 
-    it("From YAML with explicit ports and intrusive validation switched on", function (done) {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: true
-        });
+    describe('intrusive checks', function() {
 
-        transformer.yamlToCompose('web:\n  image: jim/jimbob\n  ports:\n   - "5000:5000"\n')
-            .then(function () {
-                done("The test should have failed on intrusive feature validation");
-            }, function (err) {
-                expect(err.message).to.equal("Composition cannot explicitly export any ports");
-                done();
+        describe('ports', function() {
+
+            it("From YAML with explicit ports and intrusive validation switched on", function (done) {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
+
+                transformer.yamlToCompose('web:\n  image: jim/jimbob\n  ports:\n   - "5000:5000"\n')
+                    .then(function () {
+                        done("The test should have failed on intrusive feature validation");
+                    }, function (err) {
+                        expect(err.message).to.equal("Composition cannot explicitly export any ports");
+                        done();
+                    });
             });
-    });
 
-    it("From YAML with auto-created volume and intrusive validation switched on", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: true
-        });
+            it("From YAML with explicit ports and intrusive validation switched on and disable intrusive validation flag enabled on a service", function () {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
 
-        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n');
-    });
-
-    it("From YAML with auto-created volume and intrusive validation switched off", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: false
-        });
-
-        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n');
-    });
-
-    it("From YAML with container volume and defined outside services", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: true
-        });
-
-        return transformer.yamlToCompose('version: \'2.0\'\nservices:\n  web:\n    image: jim/jimbob\n    volumes:\n     - "some-container-volume:/j/b"\nvolumes:\n  data:\n   external: some-container-volume');
-    });
-
-    it("From YAML with container volume and defined outside services", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: true
-        });
-
-        return transformer.yamlToCompose('version: \'2.0\'\nservices:\n  web:\n    image: jim/jimbob\n    volumes:\n     - "/j/b:/j/b"\nvolumes:\n  data:\n   external: some-container-volume')
-            .then(function () {
-                return Q.reject(new Error('The test should have failed on intrusive feature validation'));
-            }, function (err) {
-                expect(err.message).to.equal('Composition cannot mount volumes from the local filesystem');
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  ports:\n   - "5000:5000"\n  dontValidateIntrusiveFeatures: true\n')
+                    .then(function (res) {
+                        expect(res).to.deep.equal(`web:\n  image: jim/jimbob\n  ports:\n    - '5000:5000'\n`);
+                    });
             });
-    });
 
-
-    it("From YAML with container volume and intrusive validation switched on", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: true
         });
 
-        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "some-container-volume:/j/b"\n');
-    });
+        describe('volumes', function() {
 
-    it("From YAML with container volume and intrusive validation switched off", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: false
-        });
+            it("From YAML with auto-created volume and intrusive validation switched on", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
 
-        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "some-container-volume:/j/b"\n');
-    });
-
-    it("From YAML with local filesystem volumes and intrusive validation switched on", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: true
-        });
-
-        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n')
-            .then(function () {
-                return Q.reject(new Error('The test should have failed on intrusive feature validation'));
-            }, function (err) {
-                expect(err.message).to.equal('Composition cannot mount volumes from the local filesystem');
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n');
             });
-    });
 
-    it("From YAML with local filesystem volumes and intrusive validation switched off", () => {
-        var transformer = new Transformer({
-            validateIntrusiveFeatures: false
+            it("From YAML with auto-created volume and intrusive validation switched off", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: false
+                });
+
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/j/b"\n');
+            });
+
+            it("From YAML with container volume and defined outside services", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
+
+                return transformer.yamlToCompose('version: \'2.0\'\nservices:\n  web:\n    image: jim/jimbob\n    volumes:\n     - "some-container-volume:/j/b"\nvolumes:\n  data:\n   external: some-container-volume');
+            });
+
+            it("From YAML with container volume and defined outside services", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
+
+                return transformer.yamlToCompose('version: \'2.0\'\nservices:\n  web:\n    image: jim/jimbob\n    volumes:\n     - "/j/b:/j/b"\nvolumes:\n  data:\n   external: some-container-volume')
+                    .then(function () {
+                        return Q.reject(new Error('The test should have failed on intrusive feature validation'));
+                    }, function (err) {
+                        expect(err.message).to.equal('Composition cannot mount volumes from the local filesystem');
+                    });
+            });
+
+            it("From YAML with container volume and intrusive validation switched on", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
+
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "some-container-volume:/j/b"\n');
+            });
+
+            it("From YAML with container volume and intrusive validation switched off", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: false
+                });
+
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "some-container-volume:/j/b"\n');
+            });
+
+            it("From YAML with local filesystem volumes and intrusive validation switched on", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
+
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n')
+                    .then(function () {
+                        return Q.reject(new Error('The test should have failed on intrusive feature validation'));
+                    }, function (err) {
+                        expect(err.message).to.equal('Composition cannot mount volumes from the local filesystem');
+                    });
+            });
+
+            it("From YAML with local filesystem volumes and intrusive validation switched off", () => {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: false
+                });
+
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n');
+            });
+
+            it("From YAML with mounted volumes and intrusive validation switched on and disable intrusive validation flag enabled on a service", function () {
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
+
+                return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n  dontValidateIntrusiveFeatures: true\n')
+                    .then(function (res) {
+                        expect(res).to.deep.equal(`web:\n  image: jim/jimbob\n  volumes:\n    - '/jim/bob:/j/b'\n`);
+                    });
+            });
+
         });
 
-        return transformer.yamlToCompose('web:\n  image: jim/jimbob\n  volumes:\n   - "/jim/bob:/j/b"\n');
-    });
+     });
 
     it("should run transform handler after replacement of composition vars", function () {
         var handlers = {

--- a/test/tests.unit.spec.js
+++ b/test/tests.unit.spec.js
@@ -452,7 +452,44 @@ describe("Transform composition", function () {
             });
 
             it("From YAML with container volume and defined outside services", () => {
-                return Q.reject(new Error("err"));
+                var transformer = new Transformer({
+                    validateIntrusiveFeatures: true
+                });
+
+                var yamlInput = {
+                    version: 2,
+                    services: {
+                        web: {
+                            image: 'jim/jimbob',
+                            volumes: ["some-container-volume:/j/b"]
+                        }
+                    },
+                    volumes: {
+                        data: {
+                            external: "some-container-volume"
+                        }
+                    }
+                };
+
+                var yamlOutput = {
+                    version: 2,
+                    services: {
+                        web: {
+                            image: 'jim/jimbob',
+                            volumes: ["some-container-volume:/j/b"]
+                        }
+                    },
+                    volumes: {
+                        data: {
+                            external: "some-container-volume"
+                        }
+                    }
+                };
+
+                return transformer.yamlToCompose(YAML.dump(yamlInput))
+                    .then(function (res) {
+                        expect(YAML.safeLoad(res)).to.deep.equal(yamlOutput);
+                    });
             });
 
             it("From YAML with container volume and defined outside services", () => {


### PR DESCRIPTION
The container logger is added to each composition from now on.
This means that in case intrusive checks are being checked we need to ignore this internal logging container since it uses volumes.

In order to achieve this there is a new field 'dontValidateIntrusiveFeatures' that can be put on the service object.

This field will cause the intrusive validator function to ignore this service.
This field will be removed by the intrusive validator.

small comment:
The api is responsible to not put this field in case intrusive features should not be validated (because otherwise this field will be left on the service and will cause an error)
